### PR TITLE
Issue 3. Adds async 

### DIFF
--- a/lib/generators/this_data/install_generator.rb
+++ b/lib/generators/this_data/install_generator.rb
@@ -22,6 +22,9 @@ ThisData.setup do |config|
 
   # Define a Logger instance if you want to debug / track errors
   # config.logger = Rails.logger unless Rails.env.production?
+
+  # Set this to false if you want ThisData.track to perform in the same thread
+  # config.asyc =               false
 end
 EOS
       end

--- a/lib/this_data/configuration.rb
+++ b/lib/this_data/configuration.rb
@@ -18,6 +18,11 @@ module ThisData
     #   > Login Intelligence API
     config_option :api_key
 
+    # When true, requests will be performed asynchronously. Setting this to
+    # false can help with debugging.
+    # Default: true
+    config_option :async
+
     # Log the events sent
     config_option :logger
 
@@ -41,6 +46,7 @@ module ThisData
 
       # set default attribute values
       @defaults = OpenStruct.new({
+        async:              true,
         user_method:        :current_user,
         user_id_method:     :id,
         user_name_method:   :name,

--- a/test/this_data/configuration_test.rb
+++ b/test/this_data/configuration_test.rb
@@ -8,20 +8,24 @@ class ThisData::ConfigurationTest < ThisData::UnitTest
     end
   end
 
-  def test_setting_api_key
+  test "setting api key" do
     assert_equal "abc-123", ThisData.configuration.api_key
   end
 
-  def test_hash_style_access
+  test "hash style access" do
     assert_equal "abc-123", ThisData.configuration[:api_key]
   end
 
-  def test_default_user_methods
+  test "default user methods" do
     assert_equal :current_user, ThisData.configuration.user_method
     assert_equal :id,     ThisData.configuration.user_id_method
     assert_equal :name,   ThisData.configuration.user_name_method
     assert_equal :email,  ThisData.configuration.user_email_method
     assert_equal :mobile, ThisData.configuration.user_mobile_method
+  end
+
+  test "asynchronous by default" do
+    assert ThisData.configuration.async
   end
 
 end

--- a/test/this_data_test.rb
+++ b/test/this_data_test.rb
@@ -2,15 +2,37 @@ require_relative "test_helper.rb"
 
 class ThisDataTest < ThisData::UnitTest
 
-  def test_track_creates_client_and_uses_track
+  test "track will use track_async when config option is true" do
+    event = stub()
+    thread = stub()
+    ThisData.expects(:track_async).with(event).returns(thread)
+
+    assert_equal thread, ThisData.track(event)
+  end
+
+  test "track will use track_with_response when config option is false" do
+    event = stub()
+    http_response = stub()
+    ThisData.expects(:track_with_response).with(event).returns(http_response)
+
+    ThisData.configuration.async = false
+    assert_equal http_response, ThisData.track(event)
+  end
+
+  test "track_with_response creates client and uses track" do
     client = stub()
     ThisData::Client.expects(:new).returns(client)
     event = stub()
     client.expects(:track).with(event)
-    ThisData.track(event)
+    ThisData.send(:track_with_response, event)
   end
 
-  def test_track_login
+  test "track_async uses a new thread" do
+    Thread.expects(:new)
+    ThisData.send(:track_async, stub())
+  end
+
+  test "track_login calls track" do
     expected = {
       verb: ThisData::Verbs::LOG_IN,
       ip: "1.2.3.4",


### PR DESCRIPTION
Resolves #3 

Adds async config option, defaulting to true. And when it is true, ThisData.track will perform its tracking in a new Thread. This allows the gem to be non-blocking.

  - [x] if it succeeds, do nothing
  - [x] if it fails because the payload has errors (4XX), log the error if the logger is configured
  - [ ] ~~if it fails because ThisData is broken (5XX) retry it once. If it still fails, log the error if the logger is configured.~~
    - Added a seperate issue: https://github.com/thisdata/thisdata-ruby/issues/4