### PR TITLE
Easier Denies

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ disclosure through timing attacks.
 
 ### Stuck?
 
-The API endpoint validates the events you send. If it's returning
+The API endpoint validates the events you send, and will return errors in the
+body of the response. Enabling logging will help you debug this.
 
 Our documentation can be read at http://help.thisdata.com. Our API will return
 error messages you can inspect if the payload is missing required attributes.

--- a/README.md
+++ b/README.md
@@ -20,72 +20,109 @@ Or install it yourself as:
 
 ## Usage
 
-### Ruby
+Our API endpoint documentation, tutorials, and sample code can all be found at
+http://help.thisdata.com
+
+### Plain Old Ruby
+
+#### Configuration
 
 Configure ThisData as follows:
 
-```
+```ruby
 ThisData.setup do |config|
-  config.api_key = "API_KEY_HERE"
+  config.api_key = "API_KEY_HERE" # Don't commit your key to source control!
+  config.logger  = Logger.new($stdout)
+  config.async   = false
 end
 ```
 
-You can then track any event by calling `ThisData.track` and passing a Hash which
-contains an event. See examples and required fields on our API documentation:
-http://help.thisdata.com/docs/apiv1events
+See `this_data/configuration.rb` for more options, and some suggested
+Ruby on Rails options in `this_data/generators/install_generator.rb`.
 
-**Important!** You should not commit your API keys to source control. Where
-possible, use environment variables / a non-committed secrets file / something
-similar.
+For example, in production you will probably want asynchronous and non-logging
+behaviour.
+
+#### Tracking an Event
+
+You can then track any event by calling `ThisData.track` and passing a Hash which
+contains an event. In the following example, we're tracking a user logging in
+to our app:
+
+```ruby
+ThisData.track(
+  {
+    ip: request.remote_ip,
+    user_agent: request.user_agent,
+    verb: ThisData::Verbs::LOG_IN,
+    user: {
+      id: user.id.to_s,
+      name: user.name,
+      email: user.email
+      mobile: user.mobile
+    }
+  }
+)
+```
+
 
 ### Rails
+
+#### Set Up
+
+We have a generator which will set some nice configuration options for Ruby on
+Rails users.
 
 Find your API key by going to [ThisData](https://thisdata.com) >
   Integrations > Login Intelligence API.
 
 Run:
 
-    rails g this_data:install YOUR_API_KEY_HERE
+```ruby
+rails g this_data:install YOUR_API_KEY_HERE
+```
 
 The generator will create a file in `config/initializers` called "this_data.rb".
 If you need to do any further configuration or customization of ThisData,
 that's the place to do it!
 
-The ThisData::TrackRequest module can be included in a ActionController, giving
-you a handy way to track requests.
+#### Tracking
 
-e.g. in `app/controllers/application_controller.rb`
+**The recommended way to track events is as above - explicitly calling
+`ThisData.track`.**
 
-    class ApplicationController < ActionController::Base
-      include ThisData::TrackRequest
+However, we do provide a `ThisData::TrackRequest` module which, when included in
+an ActionController, gives you a simple way to track requests.
 
-      ...
-    end
+You include the module, then call `thisdata_track`. Easy!
 
+e.g. in your sessions controller:
 
-and in your sessions controller:
+```ruby
+class SessionsController < ApplicationController
+  include ThisData::TrackRequest
 
-    class SessionsController
-      def create
-        if User.authenticate(params[:email], params[:password])
-          # Do the things one usually does for a successful auth
+  def create
+    if User.authenticate(params[:email], params[:password])
+      # Do the things one usually does for a successful auth
 
-          # And also track the login
-          thisdata_track
-        else
-          # Their credentials are wrong. Are they trying to access
-          # a valid account?
-          if attempted_user = User.find_by(email: params[:email])
-            thisdata_track(
-              verb: ThisData::Verbs::LOG_IN_DENIED,
-              user: attempted_user
-            )
-          else
-            # email and password were both incorrect
-          end
-        end
+      # And also track the login
+      thisdata_track
+    else
+      # Their credentials are wrong. Are they trying to access
+      # a valid account?
+      if attempted_user = User.find_by(email: params[:email])
+        thisdata_track(
+          verb: ThisData::Verbs::LOG_IN_DENIED,
+          user: attempted_user
+        )
+      else
+        # email and password were both incorrect
       end
     end
+  end
+end
+```
 
 Note: as with many sensitive operations, taking different actions when an
 account exists vs. when an account doesn't exist can lead to a information
@@ -94,18 +131,7 @@ disclosure through timing attacks.
 
 ### Stuck?
 
-By default there is no logger configured, and requests are performed
-asynchronously. The following config settings can be helpful in debugging issues:
-
-`config/initializers/this_data.rb`
-```
-ThisData.setup do |config|
-  # ...
-
-  config.logger = Rails.logger # or Logger.new($stdout)
-  config.async  = false
-end
-```
+The API endpoint validates the events you send. If it's returning
 
 Our documentation can be read at http://help.thisdata.com. Our API will return
 error messages you can inspect if the payload is missing required attributes.

--- a/lib/generators/this_data/install_generator.rb
+++ b/lib/generators/this_data/install_generator.rb
@@ -7,24 +7,51 @@ module ThisData
     def create_configuration_file
       initializer "this_data.rb" do
         <<-EOS
+# Specifies configuration options for the ThisData gem.
 ThisData.setup do |config|
+
+  # This is where your API key goes. You should almost certainly not have it
+  # committed to source control, but instead load it from a secret store.
+  # Default: nil
   config.api_key = "#{api_key}"
 
-  # user_method will be called on a controller when using TrackRequest
+  # Define a Logger instance if you want to debug or track errors
+  # This tells ThisData to log in the development environment.
+  # Comment it out to use the default behaviour across all environments.
+  # Default: nil
+  config.logger = Rails.logger if Rails.env.development?
+
+  # When true, will perform track events asynchronously.
+  # It is true by default, but here we explicitly tell ThisData to make it
+  # synchronous in test and development mode, to aide getting started.
+  # Comment it out to use the default behaviour across all environments.
+  # Default: true
+  config.async  = !(Rails.env.test? || Rails.env.development?)
+
+
+  # These configuration options are used when for the TrackRequest module.
+
+  # user_method will be called on a controller to get a user object.
+  # Default: :current_user
   # config.user_method =        :current_user
 
   # The following methods will be called on the object returned by user_method,
   # to capture details about the user
+
+  # Required. This method should return a unique ID for a user.
+  # Default: :id
   # config.user_id_method =     :id
+
+  # Optional. This method should return the user's name.
+  # Default: :name
   # config.user_name_method =   :name
+  # This method should return the user's email.
+  # Default: :email
   # config.user_email_method =  :email
+  # This method should return the user's mobile phone number.
+  # Default: :mobile
   # config.user_mobile_method = :mobile
 
-  # Define a Logger instance if you want to debug / track errors
-  # config.logger = Rails.logger unless Rails.env.production?
-
-  # Set this to false if you want ThisData.track to perform in the same thread
-  # config.async =               false
 end
 EOS
       end

--- a/lib/this_data.rb
+++ b/lib/this_data.rb
@@ -74,7 +74,11 @@ module ThisData
       # Returns an HTTPResponse
       def track_with_response(event)
         response = Client.new.track(event)
-        log("Tracked event!")
+        if response.try(:success?)
+          log("Tracked event! #{response.response.inspect}")
+        else
+          warn("Track failure! #{response.response.inspect} #{response.body}")
+        end
         response
       rescue => e
         ThisData.error("Failed to track event:")

--- a/lib/this_data/track_request.rb
+++ b/lib/this_data/track_request.rb
@@ -15,6 +15,13 @@ module ThisData
     #   verb: (String, Required). Defaults to ThisData::Verbs::LOG_IN.
     #   user: (Object, Optional). If you want to override the user record
     #     that we would usually fetch, you can pass it here.
+    #     Unless a user is specified here we'll attempt to get the user record
+    #       as specified in the ThisData gem configuration. This defaults to
+    #       `current_user`.
+    #     The object must respond to at least
+    #       `ThisData.configuration.user_id_method`, which defaults to `id`.
+    #
+    # Returns the result of ThisData.track (an HTTPartyResponse)
     def thisdata_track(verb: ThisData::Verbs::LOG_IN, user: nil)
       if user.nil?
         user = send(ThisData.configuration.user_method)
@@ -37,8 +44,10 @@ module ThisData
 
     private
 
-      # Will return a Hash of details for a user.
-      # Will raise a NoMethodError if user does not respond to `user_id_method`.
+      # Will return a Hash of details for a user using the methods specified
+      # in the gem configuration.
+      # Will raise a NoMethodError if user does not respond the
+      # specified `user_id_method`. A user id is required for all events.
       def user_details(user)
         {
           id:     user.send(ThisData.configuration.user_id_method),

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,7 @@ class ThisData::UnitTest < Minitest::Test
   def setup
     FakeWeb.allow_net_connect = false
     ThisData.configuration.api_key = "test api key"
+    ThisData.configuration.async = false
   end
 
   def register_successful_events

--- a/test/this_data/client_test.rb
+++ b/test/this_data/client_test.rb
@@ -29,9 +29,4 @@ class ThisData::ClientTest < ThisData::UnitTest
     assert response.success?
   end
 
-  def test_errors_are_caught_asd
-    ThisData::Client.expects(:post).raises("An error!")
-    refute @client.track({})
-  end
-
 end

--- a/test/this_data/track_request_test.rb
+++ b/test/this_data/track_request_test.rb
@@ -92,6 +92,11 @@ class ThisData::TrackRequestTest < ThisData::UnitTest
   end
 
   test "thisdata_track creates and posts an event containing user and request details" do
+    ThisData.expects(:track).with(has_key(verb: 'foo')).once
+    @controller.thisdata_track(verb: 'foo')
+  end
+
+  test "thisdata_track creates and posts an event containing user and request details" do
     request = stub(remote_ip: "1.2.3.4", user_agent: "Chrome User Agent")
     @controller.request = request
 

--- a/test/this_data/track_request_test.rb
+++ b/test/this_data/track_request_test.rb
@@ -14,42 +14,81 @@ end
 class ThisData::TrackRequestTest < ThisData::UnitTest
 
   def setup
+    super
+    register_successful_events
     @controller = FakeController.new
+    @controller.request = stub(remote_ip: nil, user_agent: nil)
   end
 
   test "user_details returns a Hash of user detail" do
     user = stub(id: "12345")
-    @controller.current_user = user
     expected = {
       id: "12345",
       name: nil,
       email: nil,
       mobile: nil
     }
-    assert_equal expected, @controller.send(:user_details)
+    assert_equal expected, @controller.send(:user_details, user)
   end
 
   test "user_details can return lots of user details" do
     user = stub(id: "12345", email: "foo@bar.com", mobile: "+1234", name: "Foo Bar")
-    @controller.current_user = user
     expected = {
       id: "12345",
       name: "Foo Bar",
       email: "foo@bar.com",
       mobile: "+1234"
     }
-    assert_equal expected, @controller.send(:user_details)
+    assert_equal expected, @controller.send(:user_details, user)
   end
 
-  test "user_details can use a different user" do
+  test "thisdata_track will fetch a user from user_method" do
+    user = stub(id: "12345")
+    @controller.current_user = user
+    @controller.expects(:user_details).with(user)
+    @controller.send(:thisdata_track)
+  end
+
+  test "thisdata_track can use a different user, from overridden user_method" do
     user1 = stub(id: "12345")
     user2 = stub(id: "67890")
     @controller.current_user = user1
     @controller.foo_user = user2
 
-    ThisData.configuration.user_method = :foo_user
+    @controller.expects(:user_details).with(user2)
 
-    assert_equal "67890", @controller.send(:user_details)[:id]
+    # Override the default `user_method`
+    ThisData.configuration.user_method = :foo_user
+    @controller.send(:thisdata_track)
+  end
+
+  test "thisdata_track accepts an explicit user instance" do
+    failed_login_user = stub(id: "12345")
+    @controller.expects(:user_details).with(failed_login_user)
+    @controller.send(:thisdata_track, user: failed_login_user)
+  end
+
+  test "thisdata_track creates and posts an event containing user and request details" do
+    request = stub(remote_ip: "1.2.3.4", user_agent: "Chrome User Agent")
+    @controller.request = request
+
+    user = stub(id: "12345", email: "foo@bar.com", mobile: "+1234", name: "Foo Bar")
+    @controller.current_user = user
+
+    expected = {
+      ip: "1.2.3.4",
+      user_agent: "Chrome User Agent",
+      verb: "log-in",
+      user: {
+        id: "12345",
+        name: "Foo Bar",
+        email: "foo@bar.com",
+        mobile: "+1234"
+      }
+    }
+
+    ThisData.expects(:track).with(expected).once
+    @controller.thisdata_track
   end
 
   test "thisdata_track creates and posts an event containing user and request details" do

--- a/test/this_data_test.rb
+++ b/test/this_data_test.rb
@@ -7,6 +7,7 @@ class ThisDataTest < ThisData::UnitTest
     thread = stub()
     ThisData.expects(:track_async).with(event).returns(thread)
 
+    ThisData.configuration.async = true
     assert_equal thread, ThisData.track(event)
   end
 


### PR DESCRIPTION
When tracking a failed login, it's really hard to use `ThisData::TrackRequest#thisdata_track` because the usually-present `current_user` object is not present. The user was not authenticated!

This PR adds the option to explicitly override the user object we're intending to track.

It also adds more logging and more tests.