### PR TITLE
9: Fix success/failure logging

### DIFF
--- a/lib/this_data.rb
+++ b/lib/this_data.rb
@@ -74,7 +74,8 @@ module ThisData
       # Returns an HTTPResponse
       def track_with_response(event)
         response = Client.new.track(event)
-        if response.try(:success?)
+        success = response.success? rescue nil # HTTParty doesn't like `.try`
+        if success
           log("Tracked event! #{response.response.inspect}")
         else
           warn("Track failure! #{response.response.inspect} #{response.body}")

--- a/lib/this_data.rb
+++ b/lib/this_data.rb
@@ -74,7 +74,7 @@ module ThisData
       # Returns an HTTPResponse
       def track_with_response(event)
         response = Client.new.track(event)
-        success = response.success? rescue nil # HTTParty doesn't like `.try`
+        success = response && response.success? # HTTParty doesn't like `.try`
         if success
           log("Tracked event! #{response.response.inspect}")
         else


### PR DESCRIPTION
Addresses issue https://github.com/thisdata/thisdata-ruby/issues/9

Calling `.try` on a HTTParty response doesn't work like you think it would, so change the syntax to check request success properly. Also add success/failure logging test cases.