### PR TITLE
Use TravisCI for builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: ruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,3 @@
 language: ruby
+before_install:
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - 2.3
+  - jruby
 before_install:
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ rvm:
   - 2.0
   - 2.1
   - 2.2
-  - jruby
 before_install:
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: ruby
 rvm:
+  - 2.0
+  - 2.1
   - 2.2
+  - 2.3
+before_install:
+  - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: ruby
+rvm:
+  - 2.2
 before_install:
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: ruby
 rvm:
   - 2.2
-before_install:
-  - gem install bundler

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ThisData Ruby
+# ThisData Ruby [![Build Status](https://travis-ci.org/thisdata/thisdata-ruby.png?branch=travis)](https://travis-ci.org/thisdata/thisdata-ruby)
 
 This gem allows you to use the ThisData Login Intelligence API.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ThisData Ruby [![Build Status](https://travis-ci.org/thisdata/thisdata-ruby.png?branch=travis)](https://travis-ci.org/thisdata/thisdata-ruby)
+# ThisData Ruby [![Build Status](https://travis-ci.org/thisdata/thisdata-ruby.png?branch=master)](https://travis-ci.org/thisdata/thisdata-ruby)
 
 This gem allows you to use the ThisData Login Intelligence API.
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,7 @@ class ThisData::UnitTest < Minitest::Test
   end
 
   def register_successful_events
-    successful_path = "https://api.thisdata.com/v1/events?api_key=#{ThisData.configuration.api_key}"
+    successful_path = URI.encode("https://api.thisdata.com/v1/events?api_key=#{ThisData.configuration.api_key}")
     FakeWeb.register_uri(:post, successful_path, body: "", status: 202)
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,7 +8,7 @@ require 'fakeweb'
 class ThisData::UnitTest < Minitest::Test
   def setup
     FakeWeb.allow_net_connect = false
-    ThisData.configuration.api_key = "test api key"
+    ThisData.configuration.api_key = "test-api-key"
     ThisData.configuration.async = false
   end
 

--- a/test/this_data_test.rb
+++ b/test/this_data_test.rb
@@ -51,7 +51,7 @@ class ThisDataTest < ThisData::UnitTest
   end
 
   test "successful track is logged" do
-    path = "https://api.thisdata.com/v1/events?api_key=#{ThisData.configuration.api_key}"
+    path = URI.encode("https://api.thisdata.com/v1/events?api_key=#{ThisData.configuration.api_key}")
     FakeWeb.register_uri(:post, path, body: "foo", status: 201)
 
     ThisData.expects(:log).with("Tracked event! #<Net::HTTPCreated 201  readbody=true>")
@@ -62,7 +62,7 @@ class ThisDataTest < ThisData::UnitTest
   end
 
   test "unsuccessful track_with_response is logged" do
-    path = "https://api.thisdata.com/v1/events?api_key=#{ThisData.configuration.api_key}"
+    path = URI.encode("https://api.thisdata.com/v1/events?api_key=#{ThisData.configuration.api_key}")
     FakeWeb.register_uri(:post, path, body: '{"error": "message"}', status: 400)
 
     ThisData.expects(:warn).with('Track failure! #<Net::HTTPBadRequest 400  readbody=true> {"error": "message"}')


### PR DESCRIPTION
It would be great to get all of the ThisData libs using Travis for builds. 

This PR adds the Travis hook and fixes a few issues which prevented tests from running on Ruby 2.0, 2.1, 2.2