### PR TITLE
Adds support for tracking ThisData's javascript cookie, when present.

### DIFF
--- a/lib/generators/this_data/install_generator.rb
+++ b/lib/generators/this_data/install_generator.rb
@@ -55,8 +55,8 @@ ThisData.setup do |config|
 
 
   # ThisData's JS library (optional) adds a cookie.
-  # If you're using the library, set this to true, so that we send the value
-  # along with track requests.
+  # If you're using the library, set this to true, so that we know to expect
+  # a cookie value
   # Default: false
   # config.expect_js_cookie = true
 

--- a/lib/generators/this_data/install_generator.rb
+++ b/lib/generators/this_data/install_generator.rb
@@ -53,6 +53,13 @@ ThisData.setup do |config|
   # Default: :mobile
   # config.user_mobile_method = :mobile
 
+
+  # ThisData's JS library (optional) adds a cookie.
+  # If you're using the library, set this to true, so that we send the value
+  # along with track requests.
+  # Default: false
+  # config.expect_js_cookie = true
+
 end
 EOS
       end

--- a/lib/this_data/client.rb
+++ b/lib/this_data/client.rb
@@ -36,6 +36,10 @@ module ThisData
     #                 *email and/or mobile MUST be passed if you want ThisData
     #                 to send 'Was This You?' notifications via email and/or SMS
     #   - name      (Optional: String)  the user's name, used in notifications
+    #  - session   (Optional: Hash) details about the user's session
+    #   - td_cookie_expected (Optional: Boolean) whether you expect a JS cookie
+    #                         to be present
+    #   - td_cookie_id       (Optional: String) the value of the JS cookie
     def track(event)
       post_event(event)
     end

--- a/lib/this_data/configuration.rb
+++ b/lib/this_data/configuration.rb
@@ -30,8 +30,8 @@ module ThisData
     config_option :logger
 
     # ThisData's JS library (optional) adds a cookie.
-    # If you're using the library, set this to true, so that we send the value
-    # along with track requests.
+    # If you're using the library, set this to true, so that we know to expect
+    # a cookie value
     config_option :expect_js_cookie
 
     # TrackRequest config options

--- a/lib/this_data/configuration.rb
+++ b/lib/this_data/configuration.rb
@@ -3,6 +3,9 @@ require "ostruct"
 module ThisData
   class Configuration
 
+    # ThisData's JS library (optional) adds a cookie with this name
+    JS_COOKIE_NAME = '__tdli'
+
     # Programatically create attr accessors for config_option
     def self.config_option(name)
       define_method(name) do
@@ -25,6 +28,11 @@ module ThisData
 
     # Log the events sent
     config_option :logger
+
+    # ThisData's JS library (optional) adds a cookie.
+    # If you're using the library, set this to true, so that we send the value
+    # along with track requests.
+    config_option :expect_js_cookie
 
     # TrackRequest config options
     # We will attempt to call this method on a Controller to get the user record
@@ -51,7 +59,8 @@ module ThisData
         user_id_method:     :id,
         user_name_method:   :name,
         user_email_method:  :email,
-        user_mobile_method: :mobile
+        user_mobile_method: :mobile,
+        expect_js_cookie:   false
       })
     end
 

--- a/lib/this_data/track_request.rb
+++ b/lib/this_data/track_request.rb
@@ -27,22 +27,17 @@ module ThisData
         user = send(ThisData.configuration.user_method)
       end
 
+
       event = {
         verb:       verb,
         ip:         request.remote_ip,
         user_agent: request.user_agent,
-        user:       user_details(user)
+        user:       user_details(user),
+        other: {
+          td_cookie_expected: ThisData.configuration.expect_js_cookie,
+          td_cookie_id:       td_cookie_value,
+        }
       }
-
-      # If we expect there to be a cookie configured, send it it along.
-      # If the cookie is nil, the user likely has an ad-blocker, but that's
-      # fine too.
-      if ThisData.configuration.expect_js_cookie
-        cookie_value = cookies[ThisData::Configuration::JS_COOKIE_NAME] rescue nil
-
-        event[:other] ||= {}
-        event[:other][:td_cookie_id] = cookie_value
-      end
 
       ThisData.track(event)
     rescue => e
@@ -76,6 +71,14 @@ module ThisData
         else
           nil
         end
+      end
+
+      # When using the optional JavaScript library, a cookie is placed which
+      # helps us track devices.
+      # If the cookie is nil, then either you aren't using the JS library, or
+      # the user likely has an ad-blocker.
+      def td_cookie_value
+        cookie_value = cookies[ThisData::Configuration::JS_COOKIE_NAME] rescue nil
       end
 
   end

--- a/lib/this_data/track_request.rb
+++ b/lib/this_data/track_request.rb
@@ -33,7 +33,7 @@ module ThisData
         ip:         request.remote_ip,
         user_agent: request.user_agent,
         user:       user_details(user),
-        other: {
+        session: {
           td_cookie_expected: ThisData.configuration.expect_js_cookie,
           td_cookie_id:       td_cookie_value,
         }

--- a/lib/this_data/track_request.rb
+++ b/lib/this_data/track_request.rb
@@ -34,6 +34,16 @@ module ThisData
         user:       user_details(user)
       }
 
+      # If we expect there to be a cookie configured, send it it along.
+      # If the cookie is nil, the user likely has an ad-blocker, but that's
+      # fine too.
+      if ThisData.configuration.expect_js_cookie
+        cookie_value = cookies[ThisData::Configuration::JS_COOKIE_NAME] rescue nil
+
+        event[:other] ||= {}
+        event[:other][:td_cookie_id] = cookie_value
+      end
+
       ThisData.track(event)
     rescue => e
       ThisData.error "Could not track event:"

--- a/lib/this_data/track_request.rb
+++ b/lib/this_data/track_request.rb
@@ -78,7 +78,7 @@ module ThisData
       # If the cookie is nil, then either you aren't using the JS library, or
       # the user likely has an ad-blocker.
       def td_cookie_value
-        cookie_value = cookies[ThisData::Configuration::JS_COOKIE_NAME] rescue nil
+        cookies[ThisData::Configuration::JS_COOKIE_NAME] rescue nil
       end
 
   end

--- a/test/this_data/track_request_test.rb
+++ b/test/this_data/track_request_test.rb
@@ -84,7 +84,7 @@ class ThisData::TrackRequestTest < ThisData::UnitTest
         email: "foo@bar.com",
         mobile: "+1234"
       },
-      other: {
+      session: {
         td_cookie_id: nil,
         td_cookie_expected: false
       }
@@ -109,7 +109,7 @@ class ThisData::TrackRequestTest < ThisData::UnitTest
     ThisData.configuration.expect_js_cookie = true
     @controller.cookies = {ThisData::Configuration::JS_COOKIE_NAME => "uuid"}
 
-    expected = {other: {td_cookie_id: "uuid", td_cookie_expected: true}}
+    expected = {session: {td_cookie_id: "uuid", td_cookie_expected: true}}
     ThisData.expects(:track).with(has_entry(expected)).once
     @controller.thisdata_track
   end
@@ -119,7 +119,7 @@ class ThisData::TrackRequestTest < ThisData::UnitTest
     ThisData.configuration.expect_js_cookie = true
     @controller.cookies = {}
 
-    expected = {other: {td_cookie_id: nil, td_cookie_expected: true}}
+    expected = {session: {td_cookie_id: nil, td_cookie_expected: true}}
     ThisData.expects(:track).with(has_entry(expected)).once
     @controller.thisdata_track
   end
@@ -128,7 +128,7 @@ class ThisData::TrackRequestTest < ThisData::UnitTest
     ThisData.configuration.expect_js_cookie = false
     @controller.cookies = {}
 
-    expected = {other: {td_cookie_id: nil, td_cookie_expected: false}}
+    expected = {session: {td_cookie_id: nil, td_cookie_expected: false}}
     ThisData.expects(:track).with(has_entry(expected)).once
     @controller.thisdata_track
   end

--- a/test/this_data/track_request_test.rb
+++ b/test/this_data/track_request_test.rb
@@ -83,6 +83,10 @@ class ThisData::TrackRequestTest < ThisData::UnitTest
         name: "Foo Bar",
         email: "foo@bar.com",
         mobile: "+1234"
+      },
+      other: {
+        td_cookie_id: nil,
+        td_cookie_expected: false
       }
     }
 
@@ -100,12 +104,13 @@ class ThisData::TrackRequestTest < ThisData::UnitTest
     assert_equal false, @controller.thisdata_track
   end
 
-  test "will look for and pass a cookie when told to" do
+  test "will look for and pass a cookie and expected state" do
     # Tell TD to look for a cookie, and place the cookie
     ThisData.configuration.expect_js_cookie = true
     @controller.cookies = {ThisData::Configuration::JS_COOKIE_NAME => "uuid"}
 
-    ThisData.expects(:track).with(has_entry(other: {td_cookie_id: "uuid"})).once
+    expected = {other: {td_cookie_id: "uuid", td_cookie_expected: true}}
+    ThisData.expects(:track).with(has_entry(expected)).once
     @controller.thisdata_track
   end
 
@@ -114,8 +119,17 @@ class ThisData::TrackRequestTest < ThisData::UnitTest
     ThisData.configuration.expect_js_cookie = true
     @controller.cookies = {}
 
+    expected = {other: {td_cookie_id: nil, td_cookie_expected: true}}
+    ThisData.expects(:track).with(has_entry(expected)).once
+    @controller.thisdata_track
+  end
 
-    ThisData.expects(:track).with(has_entry(other: {td_cookie_id: nil})).once
+  test "will look for a cookie and pass nil if not expected" do
+    ThisData.configuration.expect_js_cookie = false
+    @controller.cookies = {}
+
+    expected = {other: {td_cookie_id: nil, td_cookie_expected: false}}
+    ThisData.expects(:track).with(has_entry(expected)).once
     @controller.thisdata_track
   end
 end


### PR DESCRIPTION
#13 

Adds support for tracking ThisData's javascript cookie when it's present, and when using our TrackRequest module. ThisData's Javascript tracking code is optional, but when included in a page will add a cookie called `__tdli`. If you're using the javascript library, you should also send through that value with server-side tracking calls, so that they can be tied together.

Added:
  - config option which determines if we should look for it (default: false)
  - code which will add the cookie value (or nil) if we're told to look for it

Also changed are some tests which shared the same name, and therefore were not run as expected.

### New default state

```ruby
{
  ip: "1.2.3.4",
  user_agent: "Chrome User Agent",
  verb: "log-in",
  user: {
    id: "12345",
    name: "Foo Bar",
    email: "foo@bar.com",
    mobile: "+1234"
  },
  session: {
    td_cookie_id: nil,
    td_cookie_expected: false
  }
}
```

### Enabled, with cookie present
```ruby
{
   ...
  session: {
    td_cookie_id: "abc1234",
    td_cookie_expected: true
  }
}
```

### Enabled, but JS blocker turned on
```ruby
{
   ...
  session: {
    td_cookie_id: nil,
    td_cookie_expected: true
  }
}
```
