### PR TITLE
19 verify get events

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,15 @@
+# 0.2.0
+
+  - Add support for two new API endpoints, POST /verify and GET /events
+    https://github.com/thisdata/thisdata-ruby/issues/19
+    - help.thisdata.com/docs/apiv1verify
+    - help.thisdata.com/docs/v1getevents
+    - `ThisData::Event.all` returns a filterable, pageable, list of Events
+    - `ThisData.verify(...)` uses ThisData to determine how likely it is that
+       the person who is currently logged in has had their account compromised.
+    - Includes `thisdata_verify` method in the TrackRequest module, for easier
+      use within Rails apps
+
 # 0.1.6
 
   - Add support for setting the authenticated value when using `thisdata_track`.

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ response = ThisData.verify(
   }
 )
 
-if response["risk_level"].eql? ThisData::RISK_LEVEL_GREEN
+if response["risk_level"] == ThisData::RISK_LEVEL_GREEN
   # Let them log in
 else
   # Challenge for a Two Factor Authentication code
@@ -181,7 +181,7 @@ class SessionsController < ApplicationController
       # They used the right credentials, but does this login look unusual?
       response = thisdata_verify
 
-      if ThisData::RISK_LEVEL_GREEN.eql? response["risk_level"]
+      if response["risk_level"] == ThisData::RISK_LEVEL_GREEN
         # The login looks OK. Do the things one usually does for a successful
         # auth
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,40 @@ account exists vs. when an account doesn't exist can lead to a information
 disclosure through timing attacks.
 
 
+#### Verifying
+
+Similar to the approach above, there is also a convenience method for verifying
+the current user.
+
+```ruby
+class SessionsController < ApplicationController
+  include ThisData::TrackRequest
+
+  def create
+    if User.authenticate(params[:email], params[:password])
+
+      # They used the right credentials, but does this login look unusual?
+      response = thisdata_verify
+
+      if ThisData::RISK_LEVEL_GREEN.eql? response["risk_level"]
+        # The login looks OK. Do the things one usually does for a successful
+        # auth
+
+        # And track it
+        thisdata_track
+      else
+        # There is a chance the account could be breached.
+        # Confirm authentication by asking for a Two Factor Authentication code
+        # ....
+      end
+
+    else
+      # Their credentials are wrong...
+    end
+  end
+end
+```
+
 ### Will this break my app?
 
 We hope not! We encourage you to use the asynchronous API call where possible

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ response = ThisData.verify(
   }
 )
 
-if response.risk_level.eql? ThisData::RISK_LEVEL_GREEN
+if response["risk_level"].eql? ThisData::RISK_LEVEL_GREEN
   # Let them log in
 else
   # Challenge for a Two Factor Authentication code

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ events = ThisData::Event.all(
   limit: 25,
   offset: 50
 )
+
+events.length
+=> 25
+
+events.first.user.id
+=> "112233"
 ```
 
 ### Rails

--- a/README.md
+++ b/README.md
@@ -66,6 +66,36 @@ ThisData.track(
 )
 ```
 
+#### Verifying a User
+
+```ruby
+response = ThisData.verify(
+  ip: request.remote_ip,
+  user_agent: request.user_agent,
+  verb: ThisData::Verbs::LOG_IN,
+  user: {
+    id: user.id
+  }
+)
+
+if response.risk_level.eql? ThisData::RISK_LEVEL_GREEN
+  # Let them log in
+else
+  # Challenge for a Two Factor Authentication code
+end
+```
+
+
+#### Getting Events (Audit Log)
+
+```ruby
+events = ThisData::Event.all(
+  verb: ThisData::Verbs::LOG_IN,
+  user_id: user.id,
+  limit: 25,
+  offset: 50
+)
+```
 
 ### Rails
 
@@ -131,6 +161,7 @@ end
 Note: as with many sensitive operations, taking different actions when an
 account exists vs. when an account doesn't exist can lead to a information
 disclosure through timing attacks.
+
 
 ### Will this break my app?
 

--- a/README.md
+++ b/README.md
@@ -52,16 +52,14 @@ to our app:
 
 ```ruby
 ThisData.track(
-  {
-    ip: request.remote_ip,
-    user_agent: request.user_agent,
-    verb: ThisData::Verbs::LOG_IN,
-    user: {
-      id: user.id.to_s,
-      name: user.name,
-      email: user.email,
-      mobile: user.mobile
-    }
+  ip: request.remote_ip,
+  user_agent: request.user_agent,
+  verb: ThisData::Verbs::LOG_IN,
+  user: {
+    id: user.id.to_s,
+    name: user.name,
+    email: user.email,
+    mobile: user.mobile
   }
 )
 ```
@@ -72,7 +70,6 @@ ThisData.track(
 response = ThisData.verify(
   ip: request.remote_ip,
   user_agent: request.user_agent,
-  verb: ThisData::Verbs::LOG_IN,
   user: {
     id: user.id
   }

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,18 @@
 require "bundler/gem_tasks"
 require "rake/testtask"
 
-Rake::TestTask.new(:test) do |t|
+Rake::TestTask.new(:test_task) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/**/*_test.rb']
+end
+
+task :test do
+  begin
+    Rake::Task['test_task'].invoke
+  rescue
+    # Supress the verbose failure output of TestTake
+  end
 end
 
 task :default => :test

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ task :test do
   begin
     Rake::Task['test_task'].invoke
   rescue
-    # Supress the verbose failure output of TestTake
+    # Supress the verbose failure output of TestTask
   end
 end
 

--- a/lib/this_data.rb
+++ b/lib/this_data.rb
@@ -29,17 +29,41 @@ module ThisData
       configuration.defaults
     end
 
-    # Tracks an event. If `ThisData.configuration.async` is true, this action
-    # will be performed in a new Thread.
-    # Event must be a Hash
-    # When performed asynchronously, true is always returned.
-    # Otherwise an HTTPRequest is returned.
+    # Tracks a user initiated event which has occurred within your app, e.g.
+    # a user logging in.
+    #
+    # Performs asynchronously if ThisData.configuration.async is true.
+    #
+    # Parameters:
+    # - event       (Required: Hash) a Hash containing details about the event.
+    #               See http://help.thisdata.com/v1.0/docs/apiv1events for a
+    #               full & current list of available options.
     def track(event)
       if ThisData.configuration.async
         track_async(event)
       else
         track_with_response(event)
       end
+    end
+
+    # Verify asks ThisData's API "is this request really from this user?",
+    # and returns a response with a risk score.
+    #
+    # Note: this method does not perform error handling.
+    #
+    # Parameters:
+    # - params      (Required: Hash) a Hash containing details about the current
+    #               request & user.
+    #               See http://help.thisdata.com/docs/apiv1verify for a
+    #               full & current list of available options.
+    #
+    # Returns a Hash
+    def verify(params)
+      response = Client.new.post(
+        '/verify',
+        body: JSON.generate(params)
+      )
+      response.parsed_response
     end
 
     # A helper method to track a log-in event. Validates that the minimum

--- a/lib/this_data.rb
+++ b/lib/this_data.rb
@@ -12,6 +12,15 @@ require "util/nested_struct"
 
 module ThisData
 
+  # API Endpoint Paths
+  EVENTS_ENDPOINT   = '/events'
+  VERIFY_ENDPOINT   = '/verify'
+
+  # Risk level constants, defined at http://help.thisdata.com/docs/apiv1verify#what-does-the-risk_level-mean
+  RISK_LEVEL_GREEN  = 'green'
+  RISK_LEVEL_ORANGE = 'orange'
+  RISK_LEVEL_RED    = 'red'
+
   class << self
 
     # Configuration Object (instance of ThisData::Configuration)
@@ -60,7 +69,7 @@ module ThisData
     # Returns a Hash
     def verify(params)
       response = Client.new.post(
-        '/verify',
+        ThisData::VERIFY_ENDPOINT,
         body: JSON.generate(params)
       )
       response.parsed_response

--- a/lib/this_data.rb
+++ b/lib/this_data.rb
@@ -2,6 +2,7 @@ require "httparty"
 require "logger"
 require "json"
 
+require "this_data/event"
 require "this_data/version"
 require "this_data/verbs"
 require "this_data/client"

--- a/lib/this_data.rb
+++ b/lib/this_data.rb
@@ -8,6 +8,7 @@ require "this_data/verbs"
 require "this_data/client"
 require "this_data/configuration"
 require "this_data/track_request"
+require "util/nested_struct"
 
 module ThisData
 

--- a/lib/this_data/client.rb
+++ b/lib/this_data/client.rb
@@ -24,25 +24,12 @@ module ThisData
       ThisData.configuration.api_key || print_api_key_warning
     end
 
-    # Tracks a user initiated event which has occurred within your app, e.g.
-    # a user logging in.
-    # See http://help.thisdata.com/v1.0/docs/apiv1events for more information.
-    # - event       (Required: Hash) the event, containing the following keys:
-    #  - verb       (Required: String) 'what' the user did, e.g. 'log-in'.
-    #                 See ThisData::Verbs for predefined options.
-    #  - ip         (Required: String) the IP address of the request
-    #  - user_agent (Optional: String) the user agent from the request
-    #  - user       (Required: Hash)
-    #   - id        (Required: String)  a unique identifier for this User
-    #   - email     (Optional*: String) the user's email address.
-    #   - mobile    (Optional*: String) a mobile phone number in E.164 format
-    #                 *email and/or mobile MUST be passed if you want ThisData
-    #                 to send 'Was This You?' notifications via email and/or SMS
-    #   - name      (Optional: String)  the user's name, used in notifications
-    #  - session   (Optional: Hash) details about the user's session
-    #   - td_cookie_expected (Optional: Boolean) whether you expect a JS cookie
-    #                         to be present
-    #   - td_cookie_id       (Optional: String) the value of the JS cookie
+    # A convenience method for tracking Events.
+    #
+    # Parameters:
+    # - event       (Required: Hash) a Hash containing details about the event.
+    #               See http://help.thisdata.com/v1.0/docs/apiv1events for a
+    #               full & current list of available options.
     def track(event)
       post('/events', body: JSON.generate(event))
     end

--- a/lib/this_data/client.rb
+++ b/lib/this_data/client.rb
@@ -15,6 +15,9 @@ module ThisData
       @headers = {
         "User-Agent" => USER_AGENT
       }
+      @default_query = {
+        api_key: ThisData.configuration.api_key
+      }
     end
 
     def require_api_key
@@ -41,18 +44,27 @@ module ThisData
     #                         to be present
     #   - td_cookie_id       (Optional: String) the value of the JS cookie
     def track(event)
-      post_event(event)
+      post('/events', body: JSON.generate(event))
+    end
+
+    # Perform a GET request against the ThisData API, with the API key
+    # prepopulated
+    def get(path, query: {})
+      query = @default_query.merge(query)
+      self.class.get(path, query: query, headers: @headers)
+    end
+
+    # Perform a POST request against the ThisData API, with the API key
+    # prepopulated
+    def post(path, query: {}, body: {})
+      query = @default_query.merge(query)
+      self.class.post(path, query: query, headers: @headers, body: body)
     end
 
     private
 
       def version
         ThisData.configuration.version
-      end
-
-      def post_event(payload_hash)
-        path_with_key = "/events?api_key=#{ThisData.configuration.api_key}"
-        self.class.post(path_with_key, headers: @headers, body: JSON.generate(payload_hash))
       end
 
       def print_api_key_warning

--- a/lib/this_data/client.rb
+++ b/lib/this_data/client.rb
@@ -4,7 +4,7 @@ module ThisData
   class Client
 
     USER_AGENT = "ThisData Ruby v#{ThisData::VERSION}"
-    NO_API_KEY_MESSAGE  = "Oops: you've got no ThisData API Key configured, so we can't send events. Specify your ThisData API key using ThisData#setup (find yours at https://thisdata.com)"
+    NO_API_KEY_MESSAGE  = "Oops: you've got no ThisData API Key configured, so we can't talk to the API. Specify your ThisData API key using ThisData#setup (find yours at https://thisdata.com)"
 
     include HTTParty
 

--- a/lib/this_data/client.rb
+++ b/lib/this_data/client.rb
@@ -31,7 +31,7 @@ module ThisData
     #               See http://help.thisdata.com/v1.0/docs/apiv1events for a
     #               full & current list of available options.
     def track(event)
-      post('/events', body: JSON.generate(event))
+      post(ThisData::EVENTS_ENDPOINT, body: JSON.generate(event))
     end
 
     # Perform a GET request against the ThisData API, with the API key

--- a/lib/this_data/event.rb
+++ b/lib/this_data/event.rb
@@ -1,0 +1,18 @@
+# A wrapper for the GET /events API
+#
+#
+module ThisData
+  class Event
+
+    # Fetch an array of Events from the ThisData API
+    # Available options can be found at
+    #   http://help.thisdata.com/docs/v1getevents
+    #
+    # Returns: Array of Hashes
+    def self.all(options={})
+      response = ThisData::Client.new.get('/events', query: options)
+      response.parsed_response["results"]
+    end
+
+  end
+end

--- a/lib/this_data/event.rb
+++ b/lib/this_data/event.rb
@@ -1,6 +1,5 @@
 # A wrapper for the GET /events API
 #
-#
 module ThisData
   class Event
 
@@ -8,10 +7,14 @@ module ThisData
     # Available options can be found at
     #   http://help.thisdata.com/docs/v1getevents
     #
-    # Returns: Array of Hashes
+    # Returns: Array of OpenStruct Event objects
     def self.all(options={})
       response = ThisData::Client.new.get('/events', query: options)
-      response.parsed_response["results"]
+      # Use NestedStruct to turn this Array of deep Hashes into an array of
+      # OpenStructs
+      response.parsed_response["results"].collect do |event_hash|
+        NestedStruct.new(event_hash)
+      end
     end
 
   end

--- a/lib/this_data/event.rb
+++ b/lib/this_data/event.rb
@@ -9,7 +9,7 @@ module ThisData
     #
     # Returns: Array of OpenStruct Event objects
     def self.all(options={})
-      response = ThisData::Client.new.get('/events', query: options)
+      response = ThisData::Client.new.get(ThisData::EVENTS_ENDPOINT, query: options)
       # Use NestedStruct to turn this Array of deep Hashes into an array of
       # OpenStructs
       response.parsed_response["results"].collect do |event_hash|

--- a/lib/this_data/track_request.rb
+++ b/lib/this_data/track_request.rb
@@ -10,7 +10,7 @@
 module ThisData
   module TrackRequest
     class ThisDataTrackError < StandardError; end
-    class CurrentUserRequiredError < ArgumentError; end
+    class NoUserSpecifiedError < ArgumentError; end
 
     # Will pull request and user details from the controller, and send an event
     # to ThisData.
@@ -86,7 +86,7 @@ module ThisData
         user = send(ThisData.configuration.user_method)
       end
       # If it's still nil, raise an error
-      raise CurrentUserRequiredError, "A user must be provided for verification" if user.nil?
+      raise NoUserSpecifiedError, "A user must be provided for verification" if user.nil?
 
       # Get a Hash of details for the user
       user_details = user_details(user)

--- a/lib/this_data/version.rb
+++ b/lib/this_data/version.rb
@@ -1,3 +1,3 @@
 module ThisData
-  VERSION = "0.1.6"
+  VERSION = "0.2.0"
 end

--- a/lib/util/nested_struct.rb
+++ b/lib/util/nested_struct.rb
@@ -1,0 +1,27 @@
+# Public: turns JSON into a deeply nested OpenStruct. Will find Hashes
+# with Hashes and within Arrays.
+class NestedStruct < OpenStruct
+  def initialize(json=Hash.new)
+    @table = {}
+
+    json.each do |key, value|
+      @table[key.to_sym] =  if value.is_a? Hash
+                              self.class.new(value)
+                            elsif value.is_a? Array
+                              # Turn all the jsons in the array into DeepStructs
+                              value.collect do |i|
+                                i.is_a?(Hash) ? self.class.new(i) : i
+                              end
+                            else
+                              value
+                            end
+
+      new_ostruct_member(key)
+    end
+  end
+
+  def as_json(*args)
+    json = super
+    json["table"]
+  end
+end

--- a/test/this_data/client_test.rb
+++ b/test/this_data/client_test.rb
@@ -29,4 +29,20 @@ class ThisData::ClientTest < ThisData::UnitTest
     assert response.success?
   end
 
+  def test_get_adds_api_key
+    @client.class.expects(:get).with('foo', has_entries(
+      query: {api_key: "test-api-key"},
+      headers: has_key("User-Agent")
+    ))
+    response = @client.get('foo')
+  end
+
+  def test_post_adds_api_key
+    @client.class.expects(:post).with('foo', has_entries(
+      query: {api_key: "test-api-key"},
+      headers: has_key("User-Agent")
+    ))
+    response = @client.post('foo')
+  end
+
 end

--- a/test/this_data/event_test.rb
+++ b/test/this_data/event_test.rb
@@ -1,0 +1,41 @@
+require_relative "../test_helper.rb"
+
+class ThisData::EventTest < ThisData::UnitTest
+
+  test "can get all events" do
+    response = {
+      total: 10,
+      results: [
+        {id: "1", overall_score: 0.5, user: {id: 112233}},
+        {id: "2", overall_score: 0.1, user: {id: 445566}}
+      ]
+    }
+    expected_path = URI.encode("https://api.thisdata.com/v1/events?api_key=#{ThisData.configuration.api_key}")
+    FakeWeb.register_uri(:get, expected_path, status: 200, body: response.to_json, content_type: "application/json")
+
+    events = ThisData::Event.all
+
+    assert_equal 2,      events.length
+    assert_equal "1",    events.first.id
+    assert_equal 445566, events.last.user.id
+  end
+
+  test "can filter events" do
+    expected_query= {
+      api_key: ThisData.configuration.api_key,
+      user_id: 112233,
+      limit: 25,
+      foo: "bar"
+    }
+    response = {total: 0, results: []}
+    expected_path = URI.encode("https://api.thisdata.com/v1/events?#{URI.encode_www_form(expected_query)}")
+    FakeWeb.register_uri(:get, expected_path, status: 200, body: response.to_json, content_type: "application/json")
+
+    ThisData::Event.all(
+      user_id: 112233,
+      limit: 25,
+      foo: "bar"
+    )
+  end
+
+end

--- a/test/this_data/track_request_test.rb
+++ b/test/this_data/track_request_test.rb
@@ -157,4 +157,49 @@ class ThisData::TrackRequestTest < ThisData::UnitTest
     ThisData.expects(:track).with(has_entry(expected)).once
     @controller.thisdata_track
   end
+
+
+
+  test "thisdata_verify will fetch a user from user_method" do
+    user = stub(id: "12345")
+    @controller.current_user = user
+    @controller.expects(:user_details).with(user)
+    @controller.send(:thisdata_verify)
+  end
+
+  test "thisdata_verify accepts an explicit user instance" do
+    user = stub(id: "12345")
+    @controller.expects(:user_details).with(user)
+    @controller.send(:thisdata_verify, user: user)
+  end
+
+  test "thisdata_verify will return nil if error" do
+    ThisData.stubs(:verify).raises(ArgumentError)
+    assert_equal nil, @controller.thisdata_verify
+  end
+
+  test "thisdata_verify creates and posts an event containing user and request details" do
+    ThisData.configuration.expect_js_cookie = true
+    @controller.cookies = {ThisData::Configuration::JS_COOKIE_NAME => "uuid"}
+    request = stub(remote_ip: "1.2.3.4", user_agent: "Chrome User Agent")
+    @controller.request = request
+
+    expected = {
+      ip: "1.2.3.4",
+      user_agent: "Chrome User Agent",
+      user: {
+        id: "12345",
+        name: "Foo Bar",
+        email: "foo@bar.com",
+        mobile: "+1234"
+      },
+      session: {
+        td_cookie_id: "uuid",
+        td_cookie_expected: true
+      }
+    }
+
+    ThisData.expects(:verify).with(expected).once
+    @controller.thisdata_verify
+  end
 end

--- a/test/this_data/track_request_test.rb
+++ b/test/this_data/track_request_test.rb
@@ -174,6 +174,11 @@ class ThisData::TrackRequestTest < ThisData::UnitTest
   end
 
   test "thisdata_verify will return nil if error" do
+    @controller.current_user = nil
+    assert_equal nil, @controller.thisdata_verify
+  end
+
+  test "thisdata_verify will return nil if there is no user" do
     ThisData.stubs(:verify).raises(ArgumentError)
     assert_equal nil, @controller.thisdata_verify
   end

--- a/test/this_data_test.rb
+++ b/test/this_data_test.rb
@@ -72,4 +72,25 @@ class ThisDataTest < ThisData::UnitTest
     )
   end
 
+
+  test "verify creates client and uses post" do
+    client = stub()
+    ThisData::Client.expects(:new).returns(client)
+    response = stub("success?" => true, parsed_response: {})
+    params = {foo: "bar"}
+    client.expects(:post).with('/verify', {body: params.to_json}).returns(response)
+    assert ThisData.send(:verify, params)
+  end
+
+  test "verify parses JSON response" do
+    response = {
+      score: 0.123,
+      risk_level: "green"
+    }
+    expected_path = URI.encode("https://api.thisdata.com/v1/verify?api_key=#{ThisData.configuration.api_key}")
+    FakeWeb.register_uri(:post, expected_path, status: 200, body: response.to_json, content_type: "application/json")
+    result = ThisData.send(:verify, {})
+    assert_equal 0.123, result["score"]
+  end
+
 end


### PR DESCRIPTION
#19

Adds support for two new API endpoints, `POST /verify` and `GET /events`

  - `ThisData::Event.all` returns a filterable, pageable, list of Events
  - `ThisData.verify(...)` uses ThisData to determine how likely it is that
       the person who is currently logged in has had their account compromised.
  - Includes `thisdata_verify` method in the TrackRequest module, for easier
      use within Rails apps
  - Examples added to the README

```ruby
response = ThisData.verify(
  ip: request.remote_ip,
  user_agent: request.user_agent,
  user: {
    id: user.id
  }
)

if response["risk_level"].eql? ThisData::RISK_LEVEL_GREEN
  # Let them log in
else
  # Challenge for a Two Factor Authentication code
end
```

```ruby
events = ThisData::Event.all(
  verb: ThisData::Verbs::LOG_IN,
  user_id: user.id,
  limit: 25,
  offset: 50
)

events.length
=> 25

events.first.user.id
=> "112233"
```
