### PR TITLE
Add CRUD for Rules API

### DIFF
--- a/lib/this_data.rb
+++ b/lib/this_data.rb
@@ -2,6 +2,7 @@ require "httparty"
 require "logger"
 require "json"
 
+require "this_data/rule"
 require "this_data/event"
 require "this_data/version"
 require "this_data/verbs"
@@ -15,6 +16,7 @@ module ThisData
   # API Endpoint Paths
   EVENTS_ENDPOINT   = '/events'
   VERIFY_ENDPOINT   = '/verify'
+  RULES_ENDPOINT    = '/rules'
 
   # Risk level constants, defined at http://help.thisdata.com/docs/apiv1verify#what-does-the-risk_level-mean
   RISK_LEVEL_GREEN  = 'green'

--- a/lib/this_data/client.rb
+++ b/lib/this_data/client.rb
@@ -48,6 +48,12 @@ module ThisData
       self.class.post(path, query: query, headers: @headers, body: body)
     end
 
+    # Perform a DELETE request against the ThisData API, with the API key
+    # prepopulated
+    def delete(path)
+      self.class.delete(path, query: @default_query, headers: @headers)
+    end
+
     private
 
       def version

--- a/lib/this_data/rule.rb
+++ b/lib/this_data/rule.rb
@@ -1,0 +1,62 @@
+# A wrapper for the GET /rules API
+#
+# Note: No error handling is included in this wrapper
+#
+module ThisData
+  class Rule
+
+    # Fetch an array of Rules from the ThisData API
+    # Available options can be found at
+    #   http://help.thisdata.com/docs/v1rules
+    #
+    # Returns: Array of OpenStruct Rule objects
+    def self.find(id)
+      response = ThisData::Client.new.get("#{ThisData::RULES_ENDPOINT}/#{id}")
+      OpenStruct.new( response.parsed_response)
+    end
+
+    # Fetch an array of Rules from the ThisData API
+    # Available options can be found at
+    #   http://help.thisdata.com/docs/v1rules
+    #
+    # Returns: Array of OpenStruct Rule objects
+    def self.all
+      response = ThisData::Client.new.get(ThisData::RULES_ENDPOINT)
+      response.parsed_response.collect do |rule_hash|
+        OpenStruct.new(rule_hash)
+      end
+    end
+
+    # Create a new rule on the ThisData API
+    # Available options can be found at
+    #   http://help.thisdata.com/docs/v1rules-1
+    #
+    # Returns: OpenStruct Rule object
+    def self.create(rule)
+      response = ThisData::Client.new.post(ThisData::RULES_ENDPOINT, body: JSON.generate(rule))
+      OpenStruct.new(response.parsed_response)
+    end
+
+    # Update a rule on the ThisData API
+    # Available options can be found at
+    #   http://help.thisdata.com/docs/v1rulesid-1
+    #
+    # Returns: OpenStruct Rule object
+    def self.update(rule)
+      rule_id = OpenStruct.new(rule).id
+      response = ThisData::Client.new.post("#{ThisData::RULES_ENDPOINT}/#{rule_id}", body: JSON.generate(rule))
+      OpenStruct.new(response.parsed_response)
+    end
+
+    # Delete a rule on the ThisData API
+    # Available options can be found at
+    #   http://help.thisdata.com/docs/v1rulesid-2
+    #
+    # Returns: OpenStruct Rule object
+    def self.destroy(id)
+      response = ThisData::Client.new.delete("#{ThisData::RULES_ENDPOINT}/#{id}")
+      response.code.eql?(204)
+    end
+
+  end
+end

--- a/lib/this_data/version.rb
+++ b/lib/this_data/version.rb
@@ -1,3 +1,3 @@
 module ThisData
-  VERSION = "0.2.0"
+  VERSION = "0.2.1"
 end

--- a/test/this_data/rule_test.rb
+++ b/test/this_data/rule_test.rb
@@ -1,0 +1,106 @@
+require_relative "../test_helper.rb"
+
+class ThisData::RuleTest < ThisData::UnitTest
+
+  test "can get all rules" do
+    response = [
+      {
+        id: "123456",
+        name: "A ruby rule",
+        description: "A basic rule",
+        type: "blacklist",
+        target: "location.ip",
+        filters: ["6.6.6.6","7.7.7.7"]
+      },
+      {
+        id: "123456789",
+        name: "A second ruby rule",
+        description: "A basic rule",
+        type: "blacklist",
+        target: "location.ip",
+        filters: ["1.1.1.1"]
+      }      
+    ]
+    expected_path = URI.encode("https://api.thisdata.com/v1/rules?api_key=#{ThisData.configuration.api_key}")
+    FakeWeb.register_uri(:get, expected_path, status: 200, body: response.to_json, content_type: "application/json")
+
+    rules = ThisData::Rule.all
+
+    assert_equal 2,      rules.length
+    assert_equal "123456",    rules.first.id
+  end
+
+  test "can get a single rule" do
+    response = {
+      id: "123456",
+      name: "A ruby rule",
+      description: "A basic rule",
+      type: "blacklist",
+      target: "location.ip",
+      filters: ["6.6.6.6","7.7.7.7"]
+    }
+
+    expected_path = URI.encode("https://api.thisdata.com/v1/rules/123456?api_key=#{ThisData.configuration.api_key}")
+    FakeWeb.register_uri(:get, expected_path, status: 200, body: response.to_json, content_type: "application/json")
+
+    rule = ThisData::Rule.find(123456)
+
+    assert_equal "123456",    rule.id
+  end
+
+  test "can create a rule" do
+    response = {
+      id: "123456",
+      name: "A ruby rule",
+      description: "A basic rule",
+      type: "blacklist",
+      target: "location.ip",
+      filters: ["6.6.6.6","7.7.7.7"]
+    }
+
+    expected_path = URI.encode("https://api.thisdata.com/v1/rules?api_key=#{ThisData.configuration.api_key}")
+    FakeWeb.register_uri(:post, expected_path, status: 201, body: response.to_json, content_type: "application/json")
+
+    rule = ThisData::Rule.create({
+      name: "A ruby rule",
+      description: "A basic rule",
+      type: "blacklist",
+      target: "location.ip",
+      filters: ["6.6.6.6","7.7.7.7"]
+    })
+
+    assert_equal "123456", rule.id
+  end
+
+  test "can update a rule" do
+    response = {
+      id: "123456",
+      name: "An updated ruby rule",
+      description: "A basic rule",
+      type: "blacklist",
+      target: "location.ip",
+      filters: ["6.6.6.6","7.7.7.7"]
+    }
+
+    expected_path = URI.encode("https://api.thisdata.com/v1/rules/123456?api_key=#{ThisData.configuration.api_key}")
+    FakeWeb.register_uri(:post, expected_path, status: 200, body: response.to_json, content_type: "application/json")
+
+    rule = ThisData::Rule.update({
+      id: "123456",
+      name: "An updated ruby rule"
+    })
+
+    assert_equal "123456", rule.id
+    assert_equal "An updated ruby rule", rule.name
+  end
+
+  test "can delete a rule" do
+    expected_path = URI.encode("https://api.thisdata.com/v1/rules/123456?api_key=#{ThisData.configuration.api_key}")
+    FakeWeb.register_uri(:delete, expected_path, status: 204, content_type: "application/json")
+
+    deleted = ThisData::Rule.destroy(123456)
+
+    assert_equal true, deleted
+  end
+
+end


### PR DESCRIPTION
Adds a find, all, create, update and destroy class methods for managing rules.

Doesn't include error handling as that has not been implemented elsewhere. It should really be added but could be done in a separate PR. 

