### PR TITLE
Upgrade to newer json gem to play nicely with other gems

### DIFF
--- a/thisdata.gemspec
+++ b/thisdata.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "httparty", "~> 0.13"
-  spec.add_runtime_dependency "json", "~> 1.8"
+  spec.add_runtime_dependency "json", "~> 2.0"
 
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Hey Rich. I'd like to propose that the `json` gem be upgraded, so that this gem will play nicely with quite a few other gems which have moved to a 2.x minimum version.